### PR TITLE
Use can/view/stache/add_bundles to add dynamicImports

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/donejs/autorender/issues"
   },
   "devDependencies": {
-    "can": "^2.3.0-beta.0",
+    "can": "^2.3.1",
 	"jquery": "^1.11.0",
     "funcunit": "^3.0.0",
     "lodash.template": "^3.6.2",

--- a/test/autorender_test.js
+++ b/test/autorender_test.js
@@ -41,3 +41,14 @@ QUnit.test("not using can.route works", function() {
 	F("#hello").exists("Content rendered");
 	F("#hello").text(/Hello world/, "Correct text");
 });
+
+QUnit.module("progressive", {
+	setup: function(){
+		F.open("//progressive/index.html");
+	}
+});
+
+QUnit.test("are added to the bundle array", function(){
+	F("#bundles").exists().text(/test\/progressive\/bar/,
+							   "Normalized name is stored");
+});

--- a/test/progressive/bar.js
+++ b/test/progressive/bar.js
@@ -1,0 +1,3 @@
+define(function(){
+
+});

--- a/test/progressive/index.html
+++ b/test/progressive/index.html
@@ -1,0 +1,14 @@
+<html>
+<head></head>
+<body>
+	<script>
+		steal = {
+			map: {
+				"test/progressive/foo": "test/progressive/bar"
+			}
+		};
+	</script>
+	<script src="../../node_modules/steal/steal.js"
+			main="test/progressive/index.stache!done-autorender"></script>
+</body>
+</html>

--- a/test/progressive/index.stache
+++ b/test/progressive/index.stache
@@ -1,0 +1,22 @@
+<html>
+	<head>
+		<title>Hello page</title>
+
+		{{asset "css"}}
+	</head>
+	<body>
+		<can-import from="test/progressive/state" as="viewModel"/>
+
+		<can-import from="test/progressive/foo">
+			{{#isResolved}}
+				<span id="bundles">{{bundles}}</span>
+			{{/isResolved}}
+		</can-import>
+
+		{{#isProduction}}
+			<script src="../../node_modules/steal/steal.production.js"></script>
+		{{else}}
+			<script src="../../node_modules/steal/steal.js"></script>
+		{{/isProduction}}
+	</body>
+</html>

--- a/test/progressive/prod.html
+++ b/test/progressive/prod.html
@@ -1,0 +1,6 @@
+<html>
+<head></head>
+<body>
+	<script src="../../node_modules/steal/steal.js" load-bundles env="production" main="test/basics/index.stache!done-autorender" bundles-path="test/basics/dist/bundles"></script>
+</body>
+</html>

--- a/test/progressive/state.js
+++ b/test/progressive/state.js
@@ -1,0 +1,14 @@
+define([
+	"can/map/map",
+	"@loader",
+	"can/route/route"
+], function(Map, loader){
+	return Map.extend({
+		bundles: function(){
+			return loader.bundle;
+		},
+		hello: function(){
+			return "world";
+		}
+	});
+});


### PR DESCRIPTION
to the System.bundle array. This is needed so that the bundle names
will be normalized, otherwise there will be errors when steal-tools does
a build or runs through live-reload. Fixes #13 

**Note** This is a breaking change and will need to be released as 0.5.0