### PR TITLE
Normalize can-wait dependency

### DIFF
--- a/src/autorender.js
+++ b/src/autorender.js
@@ -41,12 +41,14 @@ define([
 	}
 
 	function translate(load){
-		var result = parse(load.source);
+		var result = parse(load.source, this);
 
-		return addBundles(result.dynamicImports, load.name).then(function(){
-
+		return Promise.all([
+			addBundles(result.dynamicImports, load.name),
+			Promise.all(result.imports)
+		]).then(function(pResults){
 			var output = template({
-				imports: JSON.stringify(result.imports),
+				imports: JSON.stringify(pResults[1]),
 				args: result.args.join(", "),
 				intermediate: JSON.stringify(result.intermediate),
 				ases: can.map(result.ases, function(from, name){
@@ -55,7 +57,6 @@ define([
 			});
 
 			return output;
-
 		});
 	}
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,8 +1,9 @@
 define([
+	"module",
 	"can/view/stache/intermediate_and_imports"
-], function(getIntermediateAndImports){
+], function(module, getIntermediateAndImports){
 
-	return function(source){
+	return function(source, loader){
 		var intermediateAndImports = getIntermediateAndImports(source);
 
 		var ases = intermediateAndImports.ases;
@@ -21,7 +22,7 @@ define([
 		});
 
 		var params = [
-			["can-wait", "wait"],
+			[loader.normalize("can-wait", module.id), "wait"],
 			["can/view/stache/stache", "stache"],
 			["module", "module"]
 		];


### PR DESCRIPTION
This normalizes can-wait before adding it to the template's dependency
list. This is so that the user doesn't need to have `can-wait` as an npm
dependency.