### PR TITLE
Upgrade deps & fix appState test

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,17 +23,17 @@
     "url": "https://github.com/donejs/autorender/issues"
   },
   "devDependencies": {
-    "can-component": "^3.0.0-pre.7",
-    "can-list": "^3.0.0-pre.3",
-    "can-map": "^3.0.0-pre.3",
-    "can-map-define": "^3.0.0-pre.2",
-    "can-route": "^3.0.0-pre.4",
-    "funcunit": "^3.0.0",
-    "lodash.template": "^3.6.2",
-    "steal": "^0.16.0",
-    "steal-qunit": "0.0.4",
-    "steal-tools": "^0.16.0",
-    "testee": "^0.2.0"
+    "can-component": "^3.0.3",
+    "can-list": "^3.0.1",
+    "can-map": "^3.0.3",
+    "can-map-define": "^3.0.1",
+    "can-route": "^3.0.5",
+    "funcunit": "^3.1.0",
+    "lodash.template": "^4.4.0",
+    "steal": "^0.16.43",
+    "steal-qunit": "0.1.4",
+    "steal-tools": "^0.16.8",
+    "testee": "^0.3.0"
   },
   "homepage": "https://github.com/donejs/autorender",
   "system": {
@@ -43,12 +43,12 @@
     }
   },
   "dependencies": {
-    "can-route": "^3.0.0-pre.4",
-    "can-stache": "^3.0.0-pre.5",
-    "can-util": "^3.0.0-pre.21",
-    "can-view-import": "^3.0.0-pre.2",
-    "can-view-model": "^3.0.0-pre.2",
-    "can-zone": "^0.5.0",
-    "steal-stache": "^3.0.0-pre.1"
+    "can-route": "^3.0.5",
+    "can-stache": "^3.0.13",
+    "can-util": "^3.0.13",
+    "can-view-import": "^3.0.3",
+    "can-view-model": "^3.1.2",
+    "can-zone": "^0.6.0",
+    "steal-stache": "^3.0.3"
   }
 }

--- a/test/basics/test.html
+++ b/test/basics/test.html
@@ -8,18 +8,23 @@
 		window.QUnit = window.parent.QUnit;
 		window.removeMyself = window.parent.removeMyself;
 	</script>
-	<script src="../../node_modules/steal/steal.js" main="test/basics/index.stache!done-autorender">
+	<script src="../../node_modules/steal/steal.js">
 		var AppViewModel = require("test/basics/state");
 		var canViewModel = require("can-view-model");
+		var Zone = require("can-zone");
 
-		var vm = canViewModel(document.documentElement);
+		new Zone().run(function() {
+			return System.import('test/basics/index.stache!done-autorender');
+		}).then(function() {
+			var vm = canViewModel(document.documentElement);
 
-		if(window.QUnit) {
-			QUnit.ok(vm instanceof AppViewModel, "got the appstate");
-			removeMyself();
-		} else {
-			console.log("Got viewModel", vm);
-		}
+			if(window.QUnit) {
+				QUnit.ok(vm instanceof AppViewModel, "got the appstate");
+				removeMyself();
+			} else {
+				console.log("Got viewModel", vm);
+			}
+		});
 	</script>
 </body>
 </html>


### PR DESCRIPTION
The test "the appState is available as the html viewModel" was failing because it was checking that the viewModel of document.documentElement was an instance of AppViewModel before done-autorender had swapped it.

The fix was to utilize a child zone to allow autorender to complete before doing the test. I don't see any drawbacks necessarily to this being asynchronous as the viewModel would be available to the rendered content regardless, but it is a break from what the previously tested behavior was