### PR TITLE
Make compatible with Steal 0.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "testee": "^0.3.0"
   },
   "homepage": "https://github.com/donejs/autorender",
-  "steal": {
+  "system": {
     "npmAlgorithm": "flat",
     "directories": {
       "lib": "src"


### PR DESCRIPTION
Only Steal 1.0 supports the "steal" package.json property. 0.16 only
supports "system". Since 1.0 supports both, using system will make
done-autorender compatible with both.

Closes #37