### PR TITLE
Prevent double rendering when main module is live-reloaded

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -31,9 +31,17 @@ define([
 
 			loader.import("live-reload", { name: module.id }).then(function(reload){
 				loader.normalize(loader.main).then(function(mainName){
+					var shouldRerender = true;
 					reload(function(){
-						document.documentElement.removeAttribute("data-attached");
-						main.renderAndAttach();
+						if(shouldRerender) {
+							document.documentElement.removeAttribute("data-attached");
+							main.renderAndAttach();
+						}
+						shouldRerender = true;
+					});
+
+					reload.dispose(mainName, function(){
+						shouldRerender = false;
 					});
 
 					reload(mainName, function(r){

--- a/test/autorender_test.js
+++ b/test/autorender_test.js
@@ -129,3 +129,13 @@ QUnit.test("It was able to load", function(){
 QUnit.asyncTest("autorender with optimized builds", function(){
 	makeIframe("basics-optimized/prod.html");
 });
+
+QUnit.module("Using live-reload", {
+	setup: function(){
+		F.open("//live-reload/page.html");
+	}
+});
+
+QUnit.test("live-reload doesn't cause double renders", function() {
+	F("#result").text("worked", "Loaded without timing out");
+});

--- a/test/live-reload/app.js
+++ b/test/live-reload/app.js
@@ -1,0 +1,43 @@
+import dep from "./dep";
+import timeout from "can-zone/timeout";
+import Zone from "can-zone";
+
+const d = dep();
+
+function MyApp() {
+	Object.defineProperty(this, "message", {
+		value: "Hello world!",
+		enumerable: false
+	});
+}
+
+MyApp.prototype.runMe = function(){
+	var zone = new Zone([
+		timeout(200)
+	]);
+
+	Zone.ignore(function(){
+		zone.run(function(){
+			d.decrement();
+			d.increment();
+		})
+		.then(function(){
+			setTimeout(function(){
+				addResult("worked");
+			}, 300);
+		}, function(err){
+			addResult("failed");
+		});
+	})();
+
+	return 'yay';
+};
+
+function addResult(txt) {
+	var div = document.getElementById("result");
+	if(div && !div.textContent) {
+		div.textContent = txt;
+	}
+}
+
+export default MyApp;

--- a/test/live-reload/config.js
+++ b/test/live-reload/config.js
@@ -1,0 +1,4 @@
+"format cjs";
+
+require("../../package.json!npm");
+require("live-reload");

--- a/test/live-reload/dep.js
+++ b/test/live-reload/dep.js
@@ -1,0 +1,27 @@
+var id;
+
+var globalZoneId = 0;
+function logZone(msg, id) {
+	return; // Comment this out for debugging
+	var zone = CanZone.current;
+	if(!zone.zoneId) {
+		zone.zoneId = globalZoneId++;
+	}
+	console.log(msg, id, 'zone:', zone.zoneId);
+}
+
+module.exports = function(){
+	return {
+		decrement: function(){
+			logZone('clearTimeout', id);
+			clearTimeout(id);
+		},
+		increment: function(){
+			id = setTimeout(function(){
+				logZone('callback', localId);
+			}, 10);
+			var localId = id;
+			logZone('setTimeout', localId);
+		}
+	};
+};

--- a/test/live-reload/index.stache
+++ b/test/live-reload/index.stache
@@ -1,0 +1,13 @@
+<html>
+<head>
+	<title>my app</title>
+</head>
+<body>
+	<can-import from="~/test/live-reload/app.js" export-as="viewModel" />
+
+	<h1>My App</h1>
+
+	<div id="result"></div>
+	<div id="running">{{runMe()}}</div>
+</body>
+</html>

--- a/test/live-reload/package.json
+++ b/test/live-reload/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "lr-example",
+	"version": "1.0.0",
+	"main": "main.js",
+	"steal": {
+		"main": "lr-example/index.stache!done-autorender",
+		"configDependencies": [
+			"config",
+			"live-reload"
+		]
+	}
+}

--- a/test/live-reload/page.html
+++ b/test/live-reload/page.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<title>live-reload example</title>
+</head>
+<body>
+	<script src="../../node_modules/steal/steal.js"
+		data-config-main="test/live-reload/config"
+		data-base-url="../../"
+		data-main="~/test/live-reload/index.stache!done-autorender"
+		data-autorender-timeout="600"></script>
+	<script type="steal-module">
+		require("~/test/live-reload/test");
+	</script>
+</body>
+</html>

--- a/test/live-reload/test.js
+++ b/test/live-reload/test.js
@@ -1,0 +1,13 @@
+var loader = require("@loader");
+var reloadAll = loader.get("live-reload").default;
+var reload = require("live-reload");
+
+window.ONRUNNING = function(){
+	debugger;
+}
+
+loader.normalize("~/test/live-reload/app").then(function(name){
+	reloadAll([name]).then(function(){
+		console.log("reloaded");
+	});
+});


### PR DESCRIPTION
Whenever rendering occurs it's possible that global state will be
mutated in such a way as to cause the Zone to timeout. To prevent this
from occuring we should make sure not to *double render*, which
increases the chance that a stateful application is put into an
unrewindable state.

Closes #110