### PR TITLE
Fixes #138. Adds can-stache-bindings as an import.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "can-route": "^4.0.0",
     "can-stache": "^4.1.5",
     "can-stache-ast": "^1.0.0",
+    "can-stache-bindings": "^4.4.0",
     "can-symbol": "^1.5.0",
     "can-util": "^3.10.18",
     "can-view-import": "^4.0.1",

--- a/src/parse.js
+++ b/src/parse.js
@@ -35,6 +35,7 @@ define([
 			[n("can-dom-mutate/node"), "mutate"],
 			[n("can-util/js/is-empty-object/is-empty-object"), "isEmptyObject"],
 			[n("can-view-import"), "canViewImport"],
+			[n("can-stache-bindings"), "canStacheBindings"],
 			[n("can-reflect"), "canReflect"],
 			[n("can-namespace"), "can"],
 			[n("full-url/index"), "fullUrl"],


### PR DESCRIPTION
Took @mjstahl's PR and updated to latest version of `can-stache-bindings`, as I needed this.

Opening this PR to see if tests pass after @matthewp recently pulled in updates to the test suite since #140 caused some tests to fail.

Thanks @mjstahl