### PR TITLE
Make live-reload work with pageComponent workflow

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -13,6 +13,7 @@ define([
 
 		var isNode = typeof process === "object" &&
 			{}.toString.call(process) === "[object process]";
+		var hasDynamicImports = true;
 
 		if(!isNode) {
 			steal.done().then(setup);
@@ -36,7 +37,11 @@ define([
 					reload(function(){
 						if(shouldRerender) {
 							document.documentElement.removeAttribute("data-attached");
-							main.renderAndAttach();
+							if(hasDynamicImports) {
+								main.renderAndAttach();
+							} else {
+								main.connectViewModelAndAttach();
+							}
 						}
 						shouldRerender = true;
 					});
@@ -84,6 +89,9 @@ define([
 				Array.prototype.push.apply(toMap, result.rawImports);
 				Array.prototype.push.apply(toMap, result.dynamicImports);
 			}
+
+			// For live-reload, determine if we should reload the viewModel
+			hasDynamicImports = result.dynamicImports.length > 0;
 
 			return Promise.all([
 				addBundles(result.dynamicImports, load.name),

--- a/test/autorender_test.js
+++ b/test/autorender_test.js
@@ -183,6 +183,12 @@ QUnit.test("The new ViewModel is bound to the route", function() {
 	});
 });
 
+QUnit.test("pageComponent style reload works", function() {
+	F("#the-page").text("2");
+	F("#load-other-page").click();
+	F("#the-page").text("3", "Updated due to live-reload reloading the page component");
+});
+
 QUnit.module("optimized builds");
 
 QUnit.test("autorender with optimized builds", function(assert) {

--- a/test/live-reload/app.js
+++ b/test/live-reload/app.js
@@ -45,6 +45,18 @@ const MyApp = DefineMap.extend("MyApp", {
 
 	setPage: function(page) {
 		this.page = page;
+	},
+
+	pageComponent: {
+		get: function() {
+			return steal.import("~/test/live-reload/other-page").then(function(fn) {
+				return fn();
+			});
+		}
+	},
+
+	reloadOtherPage: function() {
+		window.LOAD_OTHER();
 	}
 });
 

--- a/test/live-reload/index.stache
+++ b/test/live-reload/index.stache
@@ -12,5 +12,9 @@
 
 	<button id="go-to-cart" on:click="setPage('cart')">Go to Cart</button>
 	<div>Current page: <span id="current-page">{{currentPage}}</span></div>
+
+	<div id="the-page">{{pageComponent.value}}</div>
+
+	<button id="load-other-page" on:click="reloadOtherPage()">Reload other page</button>
 </body>
 </html>

--- a/test/live-reload/other-page.js
+++ b/test/live-reload/other-page.js
@@ -1,0 +1,8 @@
+
+window.OTHER_STATE = window.OTHER_STATE || 1;
+
+module.exports = function() {
+	var current = window.OTHER_STATE;
+	window.OTHER_STATE++;
+	return current;
+};

--- a/test/live-reload/test.js
+++ b/test/live-reload/test.js
@@ -6,8 +6,20 @@ window.ONRUNNING = function(){
 	debugger;
 }
 
-loader.normalize("~/test/live-reload/app").then(function(name){
-	reloadAll([name]).then(function(){
-		//console.log("reloaded");
+function reloadName(moduleName) {
+	return loader.normalize(moduleName).then(function(name){
+		return reloadAll([name]).then(function(){
+
+		});
 	});
-});
+}
+
+var reloadApp = reloadName.bind(null, "~/test/live-reload/app");
+var reloadOther = reloadName.bind(null, "~/test/live-reload/other-page");
+
+
+reloadApp();
+
+window.LOAD_OTHER = function() {
+	reloadOther();
+};


### PR DESCRIPTION
When using pageComponents create a new ViewModel on each reload. This is
because the state of the component is within the viewModel and not the
stache template (as is the case when dynamic imports occur within the
		stache).

Fixes #202